### PR TITLE
Fix SM2withSM3 OID and add test for SM2 certificate validation

### DIFF
--- a/pki/path_builder_unittest.cc
+++ b/pki/path_builder_unittest.cc
@@ -2921,4 +2921,42 @@ TEST(PathBuilderPrioritizationTest, SelfIssuedPrioritization) {
 
 }  // namespace
 
+TEST(PathBuilderTest, SM2SelfSignedRoot) {
+  std::shared_ptr<const ParsedCertificate> sm2_root_cert =
+      ReadCertFromFile("test/certs/sm2/chain-ca.crt");
+  ASSERT_TRUE(sm2_root_cert);
+
+  TrustStoreInMemory trust_store;
+  trust_store.AddTrustAnchor(sm2_root_cert);
+
+  TestPathBuilderDelegate delegate(
+      1024, TestPathBuilderDelegate::DigestPolicy::kWeakAllowSha1);
+  der::GeneralizedTime time = {2019, 1, 1, 0, 0, 0};
+
+  const InitialExplicitPolicy initial_explicit_policy =
+      InitialExplicitPolicy::kFalse;
+  const std::set<der::Input> user_initial_policy_set = {
+      der::Input(kAnyPolicyOid)};
+  const InitialPolicyMappingInhibit initial_policy_mapping_inhibit =
+      InitialPolicyMappingInhibit::kFalse;
+  const InitialAnyPolicyInhibit initial_any_policy_inhibit =
+      InitialAnyPolicyInhibit::kFalse;
+
+  CertPathBuilder path_builder(
+      sm2_root_cert, &trust_store, &delegate, time, KeyPurpose::ANY_EKU,
+      initial_explicit_policy, user_initial_policy_set,
+      initial_policy_mapping_inhibit, initial_any_policy_inhibit);
+
+  auto result = path_builder.Run();
+
+  ASSERT_TRUE(result.HasValidPath());
+  VerifyError error = result.GetBestPathVerifyError();
+  ASSERT_EQ(error.Code(), VerifyError::StatusCode::PATH_VERIFIED)
+      << error.DiagnosticString();
+  const auto &path = *result.GetBestValidPath();
+  ASSERT_EQ(2U, path.certs.size());
+  EXPECT_EQ(sm2_root_cert, path.certs[0]);
+  EXPECT_EQ(sm2_root_cert, path.certs[1]);
+}
+
 }  // namespace bssl

--- a/pki/signature_algorithm.cc
+++ b/pki/signature_algorithm.cc
@@ -125,7 +125,7 @@ const uint8_t kOidMgf1[] = {0x2a, 0x86, 0x48, 0x86, 0xf7,
 
 // In dotted notation: 1.2.156.10197.1.501
 const uint8_t kOidSm2WithSm3[] = {0x2a, 0x81, 0x1c, 0xcf, 0x55,
-                                  0x01, 0x87, 0x75};
+                                  0x01, 0x83, 0x75};
 
 // Returns true if the entirety of the input is a NULL value.
 [[nodiscard]] bool IsNull(der::Input input) {


### PR DESCRIPTION
I corrected a typo in the ASN.1 OID definition for SM2withSM3 (1.2.156.10197.1.501) in `pki/signature_algorithm.cc`. The byte for the final sub-identifier was `0x87` and has been corrected to `0x83`.

This error prevented correct parsing of the SM2withSM3 signature algorithm, leading to `kUnacceptableSignatureAlgorithm` errors during certificate path validation even when the validation delegate (e.g., `SimplePathBuilderDelegate`) was configured to accept SM2.

I added a new test case `SM2SelfSignedRoot` to `pki/path_builder_unittest.cc` which verifies a self-signed SM2 root certificate. This test now passes with the corrected OID, confirming that SM2-signed certificates can be correctly parsed and validated.
